### PR TITLE
Update workflows to include develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "develop"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -16,6 +17,7 @@ updates:
     directory: "/firebase/functions"
     schedule:
       interval: "weekly"
+    target-branch: "develop"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -28,5 +30,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    target-branch: "develop"
     labels:
       - "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, develop]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, develop]
 
 jobs:
   lint-and-typecheck:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [master, main]
+    branches: [master, main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,9 @@ name: Security Checks
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, develop]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, develop]
   schedule:
     # Run weekly on Monday at 9am UTC
     - cron: '0 9 * * 1'


### PR DESCRIPTION
## Summary
- CI, security, and dependency-review workflows now trigger on develop branch
- Dependabot PRs now target develop instead of main
- Enables CI checks for PRs targeting develop

## Changes
- `.github/workflows/ci.yml`: Added develop to branches list
- `.github/workflows/security.yml`: Added develop to branches list  
- `.github/workflows/dependency-review.yml`: Added develop to branches list
- `.github/dependabot.yml`: Added `target-branch: "develop"` for all package ecosystems

This aligns with the branch strategy: feature → develop → main

**Dependencies:** Should be merged after #38 (TypeScript fixes) to pass CI.

**Note:** Existing Dependabot PRs (#17-23) will remain targeting main. New PRs will target develop.