### PR TITLE
Fix Reset Data not clearing in-memory state

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -15,6 +15,7 @@ import {
   saveSettings,
   loadDailyState,
   saveDailyState,
+  resetAll,
 } from '../services/persistence';
 import {
   getTodayDate,
@@ -381,6 +382,30 @@ export function AppProvider({ children }: AppProviderProps): React.ReactElement 
     }
   };
 
+  /**
+   * Reset all app data - clears storage AND in-memory state
+   * Used when user wants to completely reset the app
+   */
+  const resetAllData = async (): Promise<void> => {
+    try {
+      // Cancel all notifications first
+      await NotificationService.cancelAllReminders();
+
+      // Clear AsyncStorage
+      await resetAll();
+
+      // Reset in-memory state to null (triggers onboarding)
+      setSettings(null);
+      setDailyState(null);
+      setError(null);
+
+      console.log('All app data has been reset (storage and memory)');
+    } catch (err) {
+      console.error('Error resetting all data:', err);
+      throw new Error('Failed to reset all data');
+    }
+  };
+
   // Context value
   const value: AppContextType = {
     settings,
@@ -393,6 +418,7 @@ export function AppProvider({ children }: AppProviderProps): React.ReactElement 
     completeReminder,
     resetDay,
     refreshData,
+    resetAllData,
   };
 
   return (

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -116,6 +116,7 @@ export interface AppContextActions {
   completeReminder: () => Promise<void>;
   resetDay: () => Promise<void>;
   refreshData: () => Promise<void>;
+  resetAllData: () => Promise<void>;
 }
 
 /**

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -22,7 +22,6 @@ import { TimePicker } from '../components/TimePicker';
 import { SegmentedControl } from '../components/SegmentedControl';
 import { calculateDailyGoal, computeReminderSchedule } from '../utils/hydration';
 import { NotificationService } from '../services/notifications';
-import { resetAll } from '../services/persistence';
 import type { ActivityLevel, ClimateType, ReminderFrequency } from '../models/types';
 
 interface SettingsScreenProps {
@@ -30,7 +29,7 @@ interface SettingsScreenProps {
 }
 
 export function SettingsScreen({ navigation }: SettingsScreenProps): React.ReactElement {
-  const { settings, updateSettings } = useApp();
+  const { settings, updateSettings, resetAllData } = useApp();
 
   // Local state for immediate UI updates
   const [weight, setWeight] = useState(settings?.weight || 70);
@@ -226,8 +225,8 @@ export function SettingsScreen({ navigation }: SettingsScreenProps): React.React
           style: 'destructive',
           onPress: async () => {
             try {
-              await NotificationService.cancelAllReminders();
-              await resetAll();
+              // Use context method to reset both storage AND in-memory state
+              await resetAllData();
               Alert.alert(
                 'Data Reset',
                 'All data has been cleared. The app will now restart.',
@@ -235,7 +234,7 @@ export function SettingsScreen({ navigation }: SettingsScreenProps): React.React
                   {
                     text: 'OK',
                     onPress: () => {
-                      // Navigate to onboarding or restart app
+                      // Navigate to onboarding - state is already cleared
                       navigation?.navigate('Onboarding');
                     },
                   },


### PR DESCRIPTION
## Summary
Fixes the bug where "Reset All Data" in Settings wasn't properly resetting the app. The button cleared AsyncStorage but not the in-memory React Context state, causing old values to still appear until a full app restart.

## Problem
When pressing "Reset Data":
1. AsyncStorage was cleared ✓
2. Navigation went to Onboarding ✓
3. But in-memory state (settings, dailyState) still held old values ✗
4. HomeScreen would show old water consumption data

## Solution
- Added `resetAllData()` method to `AppContextType` interface
- Implemented in `AppContext` to:
  - Cancel all notifications
  - Clear AsyncStorage via `resetAll()`
  - Reset in-memory state (`settings`, `dailyState`) to `null`
- Updated `SettingsScreen` to use the new context method

## Files Changed
- `src/models/types.ts` - Added `resetAllData` to interface
- `src/context/AppContext.tsx` - Implemented `resetAllData()`
- `src/screens/SettingsScreen.tsx` - Use context method instead of direct storage call

## Test Plan
- [ ] Go to Settings > Reset All Data
- [ ] Confirm reset in dialog
- [ ] Verify app navigates to Onboarding
- [ ] Complete onboarding with new values
- [ ] Verify HomeScreen shows fresh data (0ml consumed)