### PR TITLE
Fix resetAllData not properly clearing app state

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -59,21 +59,27 @@ export function AppProvider({ children }: AppProviderProps): React.ReactElement 
         const loadedSettings = await loadSettings();
         setSettings(loadedSettings);
 
-        // Load today's state
-        const today = getTodayDate();
-        const loadedState = await loadDailyState(today);
+        // Only load daily state if settings exist (user has completed onboarding)
+        if (loadedSettings !== null) {
+          // Load today's state
+          const today = getTodayDate();
+          const loadedState = await loadDailyState(today);
 
-        // If loaded state is from a previous day, reset it
-        if (loadedState.date !== today) {
-          const newState: DailyState = {
-            ...DEFAULT_DAILY_STATE,
-            date: today,
-            remainingML: loadedSettings.dailyGoalML,
-          };
-          await saveDailyState(newState);
-          setDailyState(newState);
+          // If loaded state is from a previous day, reset it
+          if (loadedState.date !== today) {
+            const newState: DailyState = {
+              ...DEFAULT_DAILY_STATE,
+              date: today,
+              remainingML: loadedSettings.dailyGoalML,
+            };
+            await saveDailyState(newState);
+            setDailyState(newState);
+          } else {
+            setDailyState(loadedState);
+          }
         } else {
-          setDailyState(loadedState);
+          // No settings exist, user needs to complete onboarding
+          setDailyState(null);
         }
       } catch (err) {
         console.error('Error loading initial data:', err);
@@ -380,9 +386,14 @@ export function AppProvider({ children }: AppProviderProps): React.ReactElement 
       const loadedSettings = await loadSettings();
       setSettings(loadedSettings);
 
-      const today = getTodayDate();
-      const loadedState = await loadDailyState(today);
-      setDailyState(loadedState);
+      // Only load daily state if settings exist
+      if (loadedSettings !== null) {
+        const today = getTodayDate();
+        const loadedState = await loadDailyState(today);
+        setDailyState(loadedState);
+      } else {
+        setDailyState(null);
+      }
     } catch (err) {
       console.error('Error refreshing data:', err);
       setError('Failed to refresh data');

--- a/src/services/persistence.ts
+++ b/src/services/persistence.ts
@@ -5,7 +5,7 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { UserSettings, DailyState } from '../models/types';
-import { DEFAULT_SETTINGS, DEFAULT_DAILY_STATE } from '../models/types';
+import { DEFAULT_DAILY_STATE } from '../models/types';
 import { getTodayDate } from '../utils/hydration';
 
 // Storage keys
@@ -18,23 +18,23 @@ const STORAGE_KEYS = {
 /**
  * Load user settings from storage
  *
- * @returns User settings or default settings if none exist
+ * @returns User settings or null if none exist (user needs to complete onboarding)
  */
-export async function loadSettings(): Promise<UserSettings> {
+export async function loadSettings(): Promise<UserSettings | null> {
   try {
     const json = await AsyncStorage.getItem(STORAGE_KEYS.SETTINGS);
 
     if (json === null) {
-      // No settings saved yet, return defaults
-      return { ...DEFAULT_SETTINGS };
+      // No settings saved yet, return null to trigger onboarding
+      return null;
     }
 
     const settings = JSON.parse(json) as UserSettings;
     return settings;
   } catch (error) {
     console.error('Error loading settings:', error);
-    // Return defaults on error
-    return { ...DEFAULT_SETTINGS };
+    // Return null on error to be safe (user will need to go through onboarding)
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes issue where resetting all data doesn't properly clear the app state, preventing users from going through onboarding again.

## Problem
After calling `resetAllData()`, the app would immediately recreate default settings instead of requiring the user to go through onboarding. This happened because:
1. `resetAllData()` cleared AsyncStorage and set state to null
2. The `loadInitialData` useEffect would run and call `loadSettings()`
3. `loadSettings()` returned `DEFAULT_SETTINGS` when storage was empty (not null)
4. This caused settings to be recreated immediately after reset

## Solution
- Modified `loadSettings()` to return `null` when no settings exist instead of `DEFAULT_SETTINGS`
- Updated `loadInitialData` useEffect to only load daily state if settings exist
- Updated `refreshData` to handle null settings properly
- Removed unused `DEFAULT_SETTINGS` import

## Changes
- `/root/gits/h2o-tender/src/services/persistence.ts`: Changed return type from `Promise<UserSettings>` to `Promise<UserSettings | null>` and return null when storage is empty
- `/root/gits/h2o-tender/src/context/AppContext.tsx`: Added null checks before loading daily state to prevent recreating state after reset

## Test Plan
- [x] TypeScript type-check passes with no errors
- [ ] Manual testing: Reset all data and verify app goes to onboarding
- [ ] Manual testing: Complete onboarding and verify app works normally
- [ ] Manual testing: Reset again and verify it works consistently

Closes #48