### PR TITLE
Fix dashboard not updating next reminder time when skipped

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -59,13 +59,24 @@ export function HomeScreen({ navigation }: HomeScreenProps): React.ReactElement 
       settings.dailyGoalML
     );
 
-    // Find next reminder based on current time
+    // Calculate which reminder index we're currently on (completed + skipped)
+    const currentReminderIndex = dailyState.remindersCompleted + dailyState.remindersSkipped;
+
+    // Find next reminder based on:
+    // 1. Must be after the current reminder index (accounting for completed/skipped)
+    // 2. Must be in the future time-wise
     const currentTime = getCurrentTime();
     const [currentHour, currentMinute] = currentTime.split(':').map(Number);
     const currentMinutes = currentHour * 60 + currentMinute;
 
-    // Find first reminder that hasn't passed yet
-    const upcoming = schedule.find((reminder) => {
+    // Filter schedule to only include reminders after current index and in the future
+    const upcoming = schedule.find((reminder, index) => {
+      // Must be after the current reminder index
+      if (index < currentReminderIndex) {
+        return false;
+      }
+
+      // Must be in the future
       const [reminderHour, reminderMinute] = reminder.time.split(':').map(Number);
       const reminderMinutes = reminderHour * 60 + reminderMinute;
       return reminderMinutes > currentMinutes;


### PR DESCRIPTION
## Summary
Fixes the dashboard not properly updating the next reminder time when a user skips a reminder.

## Problem
When a user skipped a reminder at 07:16:
- The toast correctly showed the updated water amount (~220ml)
- But the dashboard still displayed 07:16 as the next reminder time
- It should have shown the NEXT scheduled time (e.g., 08:16)

## Root Cause
The dashboard was only filtering reminders based on time (reminders in the future), but wasn't accounting for reminders that had already been completed or skipped. This meant it would keep showing the same reminder time even after it was skipped.

## Solution
Modified the next reminder calculation in `HomeScreen.tsx` to:
1. Track which reminder index we're currently on using `remindersCompleted + remindersSkipped`
2. Filter the schedule to only show reminders that are:
   - After the current reminder index
   - In the future time-wise

This ensures the dashboard always shows the correct upcoming reminder, accounting for both completed and skipped reminders.

## Testing
- Type check passes: `npm run type-check`
- No TypeScript errors
- Logic verified against issue description

Closes #50