### PR TITLE
Fix next reminder not updating after skip button press

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -107,7 +107,7 @@ export function HomeScreen({ navigation }: HomeScreenProps): React.ReactElement 
     } else {
       setNextReminder(null);
     }
-  }, [settings, dailyState]);
+  }, [settings, dailyState, dailyState?.remindersSkipped, dailyState?.remindersCompleted]);
 
   /**
    * Check if user is adding water too rapidly


### PR DESCRIPTION
## Summary
Fixes issue where the next reminder time wasn't updating on the dashboard after pressing the skip button.

## Problem
When user pressed "Skip" on a reminder:
- The console showed the skip was registered
- The water amount updated correctly
- But the reminder TIME stayed the same instead of advancing to the next scheduled time

## Root Cause
The useEffect that calculates the next reminder had `[settings, dailyState]` as dependencies. While `dailyState` is a new object reference when updated, React may not always detect nested property changes reliably.

## Solution
Added explicit dependencies for `dailyState?.remindersSkipped` and `dailyState?.remindersCompleted` to ensure the effect re-runs when these specific values change.

```javascript
}, [settings, dailyState, dailyState?.remindersSkipped, dailyState?.remindersCompleted]);
```

Closes #52