### PR TITLE
Add test notification function for development

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -256,6 +256,19 @@ export function SettingsScreen({ navigation }: SettingsScreenProps): React.React
     setShowDonationModal(true);
   };
 
+  // Test notification (dev mode only)
+  const handleTestNotification = async () => {
+    try {
+      await NotificationService.scheduleTestNotification(1);
+      Alert.alert(
+        'Test Scheduled',
+        'A test notification will appear in 1 minute. You can test "Drink Now" and "Skip" actions.'
+      );
+    } catch (error) {
+      Alert.alert('Error', 'Failed to schedule test notification');
+    }
+  };
+
   // Activity level labels
   const activityLabels: Record<ActivityLevel, string> = {
     none: 'None',
@@ -396,6 +409,20 @@ export function SettingsScreen({ navigation }: SettingsScreenProps): React.React
             </Text>
           </TouchableOpacity>
         </View>
+
+        {/* Developer Tools Section - DEV MODE ONLY */}
+        {__DEV__ && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Developer Tools</Text>
+            <TouchableOpacity
+              style={[styles.actionButton, styles.devButton]}
+              onPress={handleTestNotification}
+              activeOpacity={0.7}
+            >
+              <Text style={styles.actionButtonText}>Test Notification (1 min)</Text>
+            </TouchableOpacity>
+          </View>
+        )}
 
         {/* Support Section */}
         <View style={styles.section}>
@@ -630,6 +657,10 @@ const styles = StyleSheet.create({
   },
   dangerButtonText: {
     color: '#E74C3C',
+  },
+  devButton: {
+    backgroundColor: '#F5F5F5',
+    borderBottomWidth: 0,
   },
   supportButton: {
     backgroundColor: '#4A90E2',

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -281,4 +281,34 @@ export class NotificationService {
       throw error;
     }
   }
+
+  /**
+   * Schedule a test notification 1-2 minutes in the future
+   * Useful for testing the full notification flow including actions
+   * DEV MODE ONLY
+   */
+  static async scheduleTestNotification(minutesFromNow: number = 1): Promise<string> {
+    try {
+      const seconds = minutesFromNow * 60;
+
+      return await Notifications.scheduleNotificationAsync({
+        content: {
+          title: 'Hydration Reminder (Test)',
+          body: 'Drink ~250 ml now. This is a test notification.',
+          categoryIdentifier: this.CATEGORY_ID,
+          data: {
+            mlAmount: 250,
+            isTest: true,
+          },
+        },
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
+          seconds: seconds,
+        },
+      });
+    } catch (error) {
+      console.error('Error scheduling test notification:', error);
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Adds a test notification function that schedules a notification 1 minute in the future, allowing developers to test the full notification flow including "Drink Now" and "Skip" actions.

## Changes
- **src/services/notifications.ts**: Added `scheduleTestNotification(minutesFromNow)` method
- **src/screens/SettingsScreen.tsx**: Added "Test Notification (1 min)" button in Developer Tools section

## Features
- Schedules notification 1 minute ahead (configurable)
- Shows notification with "Drink Now" and "Skip" action buttons
- Button only visible in dev mode (`__DEV__` flag)
- Hidden in production builds

## Test Plan
- [ ] Open Settings in dev mode
- [ ] See "Developer Tools" section
- [ ] Tap "Test Notification (1 min)"
- [ ] Wait 1 minute for notification
- [ ] Test "Drink Now" action
- [ ] Test "Skip" action

Closes #56