### PR TITLE
Fix iOS notification config: remove duplicates, add remote-notification

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,8 +21,7 @@
         "UIBackgroundModes": [
           "location",
           "fetch",
-          "location",
-          "fetch"
+          "remote-notification"
         ],
         "NSLocationWhenInUseUsageDescription": "We use your location to determine your local climate and provide accurate hydration recommendations.",
         "NSLocationAlwaysUsageDescription": "We use your location to determine your local climate and provide accurate hydration recommendations.",


### PR DESCRIPTION
## Summary
- Removed duplicate "location" and "fetch" entries from UIBackgroundModes in app.json
- Added "remote-notification" to enable iOS push notifications

## Changes
Fixed the iOS configuration in `app.json` (lines 21-25):
- Before: UIBackgroundModes had duplicate entries: ["location", "fetch", "location", "fetch"]
- After: UIBackgroundModes now has unique entries with remote-notification support: ["location", "fetch", "remote-notification"]

## Test plan
- [x] Verified `npm run type-check` passes with no errors
- [x] Verified `npm run lint` passes with no new errors (only pre-existing warnings)
- [x] Confirmed app.json syntax is valid JSON

## Impact
This fix enables proper iOS push notification support and removes configuration redundancy that could cause issues during builds.